### PR TITLE
3X Optimization of Topology Inter-Block All-Reduce.

### DIFF
--- a/csrc/include/topo/topo.cuh
+++ b/csrc/include/topo/topo.cuh
@@ -12,7 +12,7 @@
 #define NANO_TO_MICRO (cuda::std::nano::den / cuda::std::micro::den)
 #define BYTE_MAX cuda::std::numeric_limits<cuda::std::underlying_type_t<cuda::std::byte>>::max()
 #define TO_MB(b) (static_cast<float>(b) / (1024.0f*1024.0f))
-#define BETA_LIN (1024.0f * 1024.0f) // 1MB
+#define BETA_MB 1024.0f // 1GB
 #include "../moe/definition/types.cuh"
 #include <cuda/cmath>
 
@@ -26,7 +26,7 @@ struct floatPair {
 
     __device__ __forceinline__
     friend bool operator<(const floatPair &lhs, const floatPair &rhs) {
-        return cuda::std::fmaf(lhs.beta, BETA_LIN, lhs.alpha) < cuda::std::fmaf(rhs.beta, BETA_LIN, rhs.alpha);
+        return fmaf(lhs.beta, BETA_MB, lhs.alpha) < fmaf(rhs.beta, BETA_MB, rhs.alpha);
     }
 
     __device__ __forceinline__

--- a/csrc/main.cu
+++ b/csrc/main.cu
@@ -376,6 +376,7 @@ void testTopologyDiscovery() {
         return false;
     };
     const auto isRemotePresent = remotePresent();
+    const auto sharedSize = n * (sizeof(floatPair) + sizeof(unsigned int));
     constexpr auto skip = 32U;
     cudaEvent_t start, stop;
     cudaEventCreate(&start);
@@ -387,15 +388,15 @@ void testTopologyDiscovery() {
         sizeof(decltype(aristos::seqNo)), 0, cudaMemcpyHostToDevice, aristos::aristosStream));
     #pragma unroll
     for (uint i = 0; i < skip; ++i) {
-        aristos::topology::discover<<<ARISTOS_SUPER_BLOCK_SIZE, ARISTOS_BLOCK_SIZE>>>(n, globalRank, isRemotePresent,
+        aristos::topology::discover<<<ARISTOS_SUPER_BLOCK_SIZE, ARISTOS_BLOCK_SIZE, sharedSize, aristos::aristosStream>>>(n, globalRank, isRemotePresent,
         pr, sHeap, flags, results);
         hostSeqNo = hostSeqNo + 1;
         CUTE_CHECK_ERROR(cudaMemcpyToSymbolAsync(aristos::seqNo, &hostSeqNo, sizeof(decltype(aristos::seqNo)),
             0, cudaMemcpyHostToDevice, aristos::aristosStream));
     }
-    CUTE_CHECK_ERROR(cudaMemset(results, 0, sizeof(floatPair)*n));
+    CUTE_CHECK_ERROR(cudaMemsetAsync(results, 0, sizeof(floatPair)*n, aristos::aristosStream));
     CUTE_CHECK_ERROR(cudaEventRecord(start, aristos::aristosStream));
-    aristos::topology::discover<<<ARISTOS_SUPER_BLOCK_SIZE, ARISTOS_BLOCK_SIZE>>>(n, globalRank, isRemotePresent,
+    aristos::topology::discover<<<ARISTOS_SUPER_BLOCK_SIZE, ARISTOS_BLOCK_SIZE, sharedSize, aristos::aristosStream>>>(n, globalRank, isRemotePresent,
         pr, sHeap, flags, results);
     CUTE_CHECK_ERROR(cudaEventRecord(stop, aristos::aristosStream));
     CUTE_CHECK_LAST();


### PR DESCRIPTION
This change:
- Introduces a new technique to perform lockless inter-block all-reduce. Note that the previous implementation, used a lock on the global memory buffer, allowing only one block to issue a reduction at any instant. In contrast, the new method uses `cuda::atomic_ref::fetch_max`, enabling all threads to _simultaneously issue their reduction requests_ offloading memory consistency and atomicity to hardware, rather than software.
- Coalesces global memory and shared memory reads and writes to avoid bank conflicts for the latter.
- Parallelizes subscription across an entire block, rather than previously using only one thread.
- Obviates shared memory requirement for subscription
- Implements rotary permutation to eliminate self-checks during subscription
- Migrates to single-precision arithmetic
- Improves code readability through new structure
- Fixes some memory traversal bugs

On two A100 GPUs, where a GPU uses 32 blocks, with 128 threads, end-to-end times of the discover kernel are:
- Previous implementation: 0.15 ms
- This change: 0.05 ms