### PR TITLE
add mathdx version

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ We support
 - C++20
 - ninja (`sudo apt install ninja-build`)
 - CMake (>= 3.28)
-- MathDX (>= 25.12.0)
+- [MathDX](https://docs.nvidia.com/cuda/mathdx/) (>= 25.12.0)
 
 ### Hardware Requirements
 - GPU architecture of at least SM 70. 

--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ We support
 - C++20
 - ninja (`sudo apt install ninja-build`)
 - CMake (>= 3.28)
+- MathDX (>= 25.12.0)
 
 ### Hardware Requirements
 - GPU architecture of at least SM 70. 


### PR DESCRIPTION
MathDX version requirements specified in readme

Motivation: If a version less than 25.12.0 is used, many errors suchas StaticBlockDim not being in the current namespace will show up, since it was moved over in 25.12.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated system requirements to include MathDX version 25.12.0 or later.
  * No changes to exported or public interfaces.
  * Low review effort; no functional or behavioral changes expected.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/osayamenja/FlashMoE/pull/25)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->